### PR TITLE
fix: support local test setup and bundle job clusters

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,9 @@
+DATABRICKS_HOST=https://dbc-xxxxxxxx-xxxx.cloud.databricks.com
+DATABRICKS_TOKEN=dapiXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+# Optional Databricks bundle variable overrides
+SPARK_VERSION=14.3.x-scala2.12
+NODE_TYPE_ID=Standard_DS3_v2
+
+# Backward compatibility only; not used by current job config
+DATABRICKS_CLUSTER_ID=auto

--- a/.github/workflows/deploy-databricks.yml
+++ b/.github/workflows/deploy-databricks.yml
@@ -12,7 +12,6 @@ jobs:
     env:
       DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
       DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
-      DATABRICKS_CLUSTER_ID: ${{ secrets.DATABRICKS_CLUSTER_ID }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -27,12 +26,12 @@ jobs:
 
       - name: Validate bundle
         run: |
-          databricks bundle validate -t dev --var="cluster_id=${DATABRICKS_CLUSTER_ID}"
+          databricks bundle validate -t dev
 
       - name: Deploy bundle to Databricks
         run: |
-          databricks bundle deploy -t dev --var="cluster_id=${DATABRICKS_CLUSTER_ID}"
+          databricks bundle deploy -t dev
 
       - name: Run deployed job
         run: |
-          databricks bundle run sample_pyspark_job -t dev --var="cluster_id=${DATABRICKS_CLUSTER_ID}"
+          databricks bundle run sample_pyspark_job -t dev

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build/
 *.egg-info/
 .DS_Store
 .databricks/
+.env.local

--- a/README.md
+++ b/README.md
@@ -26,14 +26,31 @@ pytest -q
 python -m src.main --output-path /tmp/pyspark_databricks_cicd/local_run
 ```
 
+## Local test setup (recommended)
+
+1. Create local env file:
+   ```bash
+   cp .env.local.example .env.local
+   ```
+2. Update `.env.local` with your Databricks values (`DATABRICKS_HOST`, `DATABRICKS_TOKEN`).
+3. Run local validation:
+   ```bash
+   chmod +x scripts/local_test.sh
+   ./scripts/local_test.sh
+   ```
+
+This script runs `pytest` and, when Databricks CLI + env vars are available, also runs `databricks bundle validate -t dev`.
+
 ## Databricks prerequisites
 
 1. Create a Databricks personal access token (PAT).
-2. Identify an existing cluster ID where the job can run.
-3. Add these GitHub repository secrets:
+2. Add these GitHub repository secrets:
    - `DATABRICKS_HOST` (example: `https://adb-1234567890123456.7.azuredatabricks.net`)
    - `DATABRICKS_TOKEN`
-   - `DATABRICKS_CLUSTER_ID`
+3. (Optional) Override cluster settings via bundle variables:
+   - `spark_version` (default: `14.3.x-scala2.12`)
+   - `node_type_id` (default: `Standard_DS3_v2`)
+4. `DATABRICKS_CLUSTER_ID=auto` is accepted in local envs for compatibility, but it is not used by the current job-cluster configuration.
 
 ## CI/CD flow
 
@@ -55,7 +72,13 @@ python -m src.main --output-path /tmp/pyspark_databricks_cicd/local_run
 ```bash
 export DATABRICKS_HOST="https://<your-databricks-workspace>"
 export DATABRICKS_TOKEN="<your-token>"
-databricks bundle validate -t dev --var="cluster_id=<your-cluster-id>"
-databricks bundle deploy -t dev --var="cluster_id=<your-cluster-id>"
-databricks bundle run sample_pyspark_job -t dev --var="cluster_id=<your-cluster-id>"
+databricks bundle validate -t dev
+databricks bundle deploy -t dev
+databricks bundle run sample_pyspark_job -t dev
+```
+
+To override default job-cluster sizing/runtime:
+
+```bash
+databricks bundle deploy -t dev --var="spark_version=14.3.x-scala2.12" --var="node_type_id=Standard_DS3_v2"
 ```

--- a/databricks.yml
+++ b/databricks.yml
@@ -10,19 +10,21 @@ artifacts:
     build: python -m pip wheel --wheel-dir dist .
 
 variables:
-  cluster_id:
-    description: Existing cluster ID where the job should run
+  spark_version:
+    description: Databricks Runtime version for job clusters
+    default: 14.3.x-scala2.12
+  node_type_id:
+    description: Node type for job clusters
+    default: Standard_DS3_v2
 
 targets:
   dev:
     mode: development
     default: true
     workspace:
-      host: ${env.DATABRICKS_HOST}
       root_path: /Workspace/Users/${workspace.current_user.userName}/.bundle/${bundle.name}/${bundle.target}
 
   prod:
     mode: production
     workspace:
-      host: ${env.DATABRICKS_HOST}
       root_path: /Workspace/Shared/.bundle/${bundle.name}/${bundle.target}

--- a/resources/sample_job.yml
+++ b/resources/sample_job.yml
@@ -2,6 +2,12 @@ resources:
   jobs:
     sample_pyspark_job:
       name: sample-pyspark-job-${bundle.target}
+      job_clusters:
+        - job_cluster_key: default_job_cluster
+          new_cluster:
+            spark_version: ${var.spark_version}
+            node_type_id: ${var.node_type_id}
+            num_workers: 1
       tasks:
         - task_key: run_sample_pipeline
           spark_python_task:
@@ -10,6 +16,6 @@ resources:
             parameters:
               - --output-path
               - /tmp/pyspark_databricks_cicd/${bundle.target}/orders
-          existing_cluster_id: ${var.cluster_id}
+          job_cluster_key: default_job_cluster
           libraries:
             - whl: ../dist/*.whl

--- a/scripts/local_test.sh
+++ b/scripts/local_test.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -f ".env.local" ]]; then
+  set -a
+  # shellcheck disable=SC1091
+  source ".env.local"
+  set +a
+fi
+
+echo "Running local unit tests..."
+PYTHON_BIN="${PYTHON_BIN:-}"
+if [[ -z "${PYTHON_BIN}" ]]; then
+  if [[ -x "./venv/bin/python" ]]; then
+    PYTHON_BIN="./venv/bin/python"
+  elif command -v python3 >/dev/null 2>&1; then
+    PYTHON_BIN="python3"
+  else
+    echo "Python not found. Install python3 or create ./venv first."
+    exit 1
+  fi
+fi
+
+"${PYTHON_BIN}" -m pip install -r requirements.txt >/dev/null
+"${PYTHON_BIN}" -m pytest -q
+
+if command -v databricks >/dev/null 2>&1; then
+  if [[ -n "${DATABRICKS_HOST:-}" && -n "${DATABRICKS_TOKEN:-}" ]]; then
+    echo "Running Databricks bundle validate..."
+    if [[ -n "${SPARK_VERSION:-}" || -n "${NODE_TYPE_ID:-}" ]]; then
+      databricks bundle validate -t dev \
+        --var="spark_version=${SPARK_VERSION:-14.3.x-scala2.12}" \
+        --var="node_type_id=${NODE_TYPE_ID:-Standard_DS3_v2}"
+    else
+      databricks bundle validate -t dev
+    fi
+  else
+    echo "Skipping Databricks validate (DATABRICKS_HOST/TOKEN not set)."
+  fi
+else
+  echo "Skipping Databricks validate (databricks CLI not installed)."
+fi
+
+if [[ -n "${DATABRICKS_CLUSTER_ID:-}" ]]; then
+  echo "Note: DATABRICKS_CLUSTER_ID is ignored by current job-cluster config."
+fi


### PR DESCRIPTION
Remove invalid auth interpolation and existing-cluster dependency by moving to bundle-managed job clusters, and add a local test script/env template for repeatable local validation.

Made-with: Cursor