### PR TITLE
fix: make Databricks deployment serverless-compatible

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,9 +1,5 @@
 DATABRICKS_HOST=https://dbc-xxxxxxxx-xxxx.cloud.databricks.com
 DATABRICKS_TOKEN=dapiXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-# Optional Databricks bundle variable overrides
-SPARK_VERSION=14.3.x-scala2.12
-NODE_TYPE_ID=Standard_DS3_v2
-
 # Backward compatibility only; not used by current job config
 DATABRICKS_CLUSTER_ID=auto

--- a/.github/workflows/deploy-databricks.yml
+++ b/.github/workflows/deploy-databricks.yml
@@ -24,6 +24,28 @@ jobs:
       - name: Set up Databricks CLI
         uses: databricks/setup-cli@main
 
+      - name: Validate Databricks auth env
+        shell: bash
+        run: |
+          CLEAN_HOST="$(echo "${DATABRICKS_HOST:-}" | tr -d '\r' | xargs)"
+          CLEAN_TOKEN="$(echo "${DATABRICKS_TOKEN:-}" | tr -d '\r' | xargs)"
+
+          if [[ -z "${CLEAN_HOST}" ]]; then
+            echo "DATABRICKS_HOST is empty."
+            exit 1
+          fi
+          if [[ ! "${CLEAN_HOST}" =~ ^https:// ]]; then
+            echo "DATABRICKS_HOST must start with https://"
+            exit 1
+          fi
+          if [[ -z "${CLEAN_TOKEN}" ]]; then
+            echo "DATABRICKS_TOKEN is empty."
+            exit 1
+          fi
+
+          echo "DATABRICKS_HOST=${CLEAN_HOST}" >> "${GITHUB_ENV}"
+          echo "DATABRICKS_TOKEN=${CLEAN_TOKEN}" >> "${GITHUB_ENV}"
+
       - name: Validate bundle
         run: |
           databricks bundle validate -t dev

--- a/README.md
+++ b/README.md
@@ -47,10 +47,9 @@ This script runs `pytest` and, when Databricks CLI + env vars are available, als
 2. Add these GitHub repository secrets:
    - `DATABRICKS_HOST` (example: `https://adb-1234567890123456.7.azuredatabricks.net`)
    - `DATABRICKS_TOKEN`
-3. (Optional) Override cluster settings via bundle variables:
-   - `spark_version` (default: `14.3.x-scala2.12`)
-   - `node_type_id` (default: `Standard_DS3_v2`)
-4. `DATABRICKS_CLUSTER_ID=auto` is accepted in local envs for compatibility, but it is not used by the current job-cluster configuration.
+   - Keep secret values plain (no leading/trailing spaces, no `KEY:` prefix)
+3. This template uses Databricks serverless job environments (compatible with serverless-only workspaces).
+4. `DATABRICKS_CLUSTER_ID=auto` is accepted in local envs for compatibility, but it is not used by the current serverless job configuration.
 
 ## CI/CD flow
 
@@ -77,8 +76,4 @@ databricks bundle deploy -t dev
 databricks bundle run sample_pyspark_job -t dev
 ```
 
-To override default job-cluster sizing/runtime:
-
-```bash
-databricks bundle deploy -t dev --var="spark_version=14.3.x-scala2.12" --var="node_type_id=Standard_DS3_v2"
-```
+No cluster sizing variables are needed for the default serverless setup.

--- a/databricks.yml
+++ b/databricks.yml
@@ -9,14 +9,6 @@ artifacts:
     type: whl
     build: python -m pip wheel --wheel-dir dist .
 
-variables:
-  spark_version:
-    description: Databricks Runtime version for job clusters
-    default: 14.3.x-scala2.12
-  node_type_id:
-    description: Node type for job clusters
-    default: Standard_DS3_v2
-
 targets:
   dev:
     mode: development

--- a/resources/sample_job.yml
+++ b/resources/sample_job.yml
@@ -2,12 +2,6 @@ resources:
   jobs:
     sample_pyspark_job:
       name: sample-pyspark-job-${bundle.target}
-      job_clusters:
-        - job_cluster_key: default_job_cluster
-          new_cluster:
-            spark_version: ${var.spark_version}
-            node_type_id: ${var.node_type_id}
-            num_workers: 1
       tasks:
         - task_key: run_sample_pipeline
           spark_python_task:
@@ -16,6 +10,10 @@ resources:
             parameters:
               - --output-path
               - /tmp/pyspark_databricks_cicd/${bundle.target}/orders
-          job_cluster_key: default_job_cluster
-          libraries:
-            - whl: ../dist/*.whl
+          environment_key: default
+      environments:
+        - environment_key: default
+          spec:
+            client: "1"
+            dependencies:
+              - ../dist/*.whl

--- a/scripts/local_test.sh
+++ b/scripts/local_test.sh
@@ -27,13 +27,7 @@ fi
 if command -v databricks >/dev/null 2>&1; then
   if [[ -n "${DATABRICKS_HOST:-}" && -n "${DATABRICKS_TOKEN:-}" ]]; then
     echo "Running Databricks bundle validate..."
-    if [[ -n "${SPARK_VERSION:-}" || -n "${NODE_TYPE_ID:-}" ]]; then
-      databricks bundle validate -t dev \
-        --var="spark_version=${SPARK_VERSION:-14.3.x-scala2.12}" \
-        --var="node_type_id=${NODE_TYPE_ID:-Standard_DS3_v2}"
-    else
-      databricks bundle validate -t dev
-    fi
+    databricks bundle validate -t dev
   else
     echo "Skipping Databricks validate (DATABRICKS_HOST/TOKEN not set)."
   fi


### PR DESCRIPTION
Switch bundle job resources to serverless environments and add workflow auth prechecks so deployment works in serverless-only workspaces with clearer secret validation failures.

Made-with: Cursor