### PR TITLE
fix: parameterize Databricks task output path

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ This script runs `pytest` and, when Databricks CLI + env vars are available, als
    - Keep secret values plain (no leading/trailing spaces, no `KEY:` prefix)
 3. This template uses Databricks serverless job environments (compatible with serverless-only workspaces), configured with environment `client: "2"`.
 4. `DATABRICKS_CLUSTER_ID=auto` is accepted in local envs for compatibility, but it is not used by the current serverless job configuration.
+5. Task parameter `--output-path` is configured via bundle variable `output_path` (default empty to avoid DBFS writes).
 
 ## CI/CD flow
 
@@ -77,3 +78,10 @@ databricks bundle run sample_pyspark_job -t dev
 ```
 
 No cluster sizing variables are needed for the default serverless setup.
+
+To provide an explicit output path during deployment/run:
+
+```bash
+databricks bundle deploy -t dev --var="output_path=/Volumes/<catalog>/<schema>/<volume>/pyspark/orders"
+databricks bundle run sample_pyspark_job -t dev --var="output_path=/Volumes/<catalog>/<schema>/<volume>/pyspark/orders"
+```

--- a/databricks.yml
+++ b/databricks.yml
@@ -9,6 +9,11 @@ artifacts:
     type: whl
     build: python -m pip wheel --wheel-dir dist .
 
+variables:
+  output_path:
+    description: Optional output path for parquet write; keep empty for no write.
+    default: ""
+
 targets:
   dev:
     mode: development

--- a/notebooks/example_notebook.py
+++ b/notebooks/example_notebook.py
@@ -8,6 +8,5 @@
 
 from src.main import run_pipeline
 
-output_path = "/tmp/pyspark_databricks_cicd/notebook_output"
-rows = run_pipeline(spark, output_path)
-print(f"Notebook pipeline completed. Rows written: {rows}")
+rows = run_pipeline(spark)
+print(f"Notebook pipeline completed. Rows processed: {rows}")

--- a/resources/sample_job.yml
+++ b/resources/sample_job.yml
@@ -9,7 +9,7 @@ resources:
             source: WORKSPACE
             parameters:
               - --output-path
-              - /tmp/pyspark_databricks_cicd/${bundle.target}/orders
+              - ${var.output_path}
           environment_key: default
       environments:
         - environment_key: default

--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+from typing import Optional
 
 from pyspark.sql import DataFrame, SparkSession
 
@@ -16,10 +17,11 @@ def create_sample_orders(spark: SparkSession) -> DataFrame:
     return spark.createDataFrame(rows, ["customer_name", "amount", "category"])
 
 
-def run_pipeline(spark: SparkSession, output_path: str) -> int:
+def run_pipeline(spark: SparkSession, output_path: Optional[str] = None) -> int:
     source_df = create_sample_orders(spark)
     transformed_df = transform_orders(source_df)
-    transformed_df.write.mode("overwrite").parquet(output_path)
+    if output_path:
+        transformed_df.write.mode("overwrite").parquet(output_path)
     return transformed_df.count()
 
 
@@ -27,8 +29,8 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run sample PySpark pipeline.")
     parser.add_argument(
         "--output-path",
-        default="/tmp/pyspark_databricks_cicd/orders",
-        help="Output path for transformed parquet data.",
+        default="",
+        help="Optional output path for transformed parquet data.",
     )
     return parser.parse_args()
 
@@ -37,7 +39,7 @@ def main() -> None:
     args = parse_args()
     spark = SparkSession.builder.appName("sample-pyspark-databricks-cicd").getOrCreate()
     row_count = run_pipeline(spark, args.output_path)
-    print(f"Pipeline completed successfully. Rows written: {row_count}")
+    print(f"Pipeline completed successfully. Rows processed: {row_count}")
     spark.stop()
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -16,3 +16,13 @@ def test_run_pipeline_writes_rows(tmp_path: Path) -> None:
     assert result_df.count() == 3
 
     spark.stop()
+
+
+def test_run_pipeline_without_output_path() -> None:
+    spark = SparkSession.builder.master("local[1]").appName("test-main-no-write").getOrCreate()
+
+    row_count = run_pipeline(spark)
+
+    assert row_count == 3
+
+    spark.stop()


### PR DESCRIPTION
Make job task parameters explicit via bundle variable output_path and default to no-write mode to stay compatible with DBFS-disabled serverless workspaces.

Made-with: Cursor